### PR TITLE
s3 test-buckets.tf fixed

### DIFF
--- a/308620678440/s3/test-buckets.tf
+++ b/308620678440/s3/test-buckets.tf
@@ -1,30 +1,4 @@
 ##
-## bucket for terraform state files
-
-/* - NEED TO FIGURE OUT WHAT TO DO Here
-This bucket is managed by terraform.tfstate
-when I run this now - this error comes out
-Error creating S3 bucket: BucketAlreadyOwnedByYou
-THIS is the bucket to store all of the Terrform state files
-
-resource "aws_s3_bucket" "ju-terraform" {
-    bucket        = "ju-terraform-state"
-    tags {
-      Environment = "sbx"
-      CreatedBy   = "terraform"
-      Purpose     = "tf-state-files"
-    }
-
-    acl           = "private"
-    versioning {
-      enabled     = true
-    }
-
-    lifecycle  {
-      prevent_destroy     = true
-    }
-}
-*/
 
 resource "aws_s3_bucket" "ju2" {
     bucket      = "shared-test-data-ju2"
@@ -35,21 +9,7 @@ resource "aws_s3_bucket" "ju2" {
     force_destroy = true
     acl           = "private"
     versioning {
-      enabled     = false
-    }
-}
-
-## bucket for test data
-resource "aws_s3_bucket" "ju3" {
-    bucket        = "shared-test-data-ju3"
-    tags {
-      Environment = "sbx"
-      CreatedBy   = "terraform"
-      Usage       = "test"
-    }
-    force_destroy = true
-    acl           = "private"
-    versioning {
       enabled     = true
     }
 }
+


### PR DESCRIPTION
Made changes to the s3 test-buckets.tf page to remove the section that creates the state bucket. This was causing an error on subsequent apply runs. Also set versioning on the test bucket. 