### PR TITLE
PR for addResources branch

### DIFF
--- a/308620678440/cloudwatch/alarms.tf
+++ b/308620678440/cloudwatch/alarms.tf
@@ -1,0 +1,24 @@
+/* note that dimensions is optional but is required to have the alarm
+linked to the specific instance
+*/
+
+
+resource "aws_cloudwatch_metric_alarm" "rds-low-cpu" {
+  alarm_name                = "rds-tf-iac-low-cpu"
+  comparison_operator       = "LessThanThreshold"
+  evaluation_periods        = "3"
+  datapoints_to_alarm       = "2"
+  metric_name               = "CPUUtilization"
+  namespace                 = "AWS/RDS"
+  period                    = "900"
+  statistic                 = "Average"
+  threshold                 = "2"
+  alarm_description         = "Low avg CPU"
+  insufficient_data_actions = []
+
+  dimensions {
+    DBInstanceIdentifier    = "tf-iac"
+  }
+
+  alarm_actions     = ["arn:aws:sns:us-west-2:308620678440:LearningTopic"]
+}

--- a/308620678440/cloudwatch/eventrules.tf
+++ b/308620678440/cloudwatch/eventrules.tf
@@ -1,0 +1,6 @@
+resource "aws_cloudwatch_event_rule" "ec2-cron" {
+  name			= "EC2-stop-cron"
+  schedule_expression	= "cron(12 3 * * ? *)"
+
+}
+

--- a/308620678440/cloudwatch/main.tf
+++ b/308620678440/cloudwatch/main.tf
@@ -1,0 +1,3 @@
+terraform {
+  backend "s3" {}
+}

--- a/308620678440/cloudwatch/provider.tf
+++ b/308620678440/cloudwatch/provider.tf
@@ -1,0 +1,3 @@
+provider "aws" {
+  region                  = "${var.aws-region}"
+}

--- a/308620678440/cloudwatch/vars.tf
+++ b/308620678440/cloudwatch/vars.tf
@@ -1,0 +1,3 @@
+variable "aws-region" {
+  default     = "us-west-2"
+}

--- a/308620678440/iam/cloudwatch-agent.tf
+++ b/308620678440/iam/cloudwatch-agent.tf
@@ -1,0 +1,53 @@
+/* role and policy for admin use with Cloudwatch Agent on EC2 and vi SSM
+   creates IAM role Trust Relationship for EC2 service
+   attaches AWS Managed Policies for CloudWatchAgentAdminPolicy and AmazonEC2RoleforSSM
+   creates instance profile for role
+*/
+
+resource "aws_iam_role" "cloudwatch-agent" {
+  name                    = "CloudwatchAgentAdmin"
+  description             = "CloudWatch agent EC2 install role"
+  max_session_duration    = "3600"
+  assume_role_policy      = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "Service": "ec2.amazonaws.com"
+      },
+      "Action": "sts:AssumeRole",
+      "Condition": {}
+    }
+  ]
+}
+EOF
+
+  tags = {
+    Environment     = "sbx"
+    CreatedBy       = "terraform"
+  }
+}
+
+######################################################
+# will use AWS Managed Policies - no additional policy creation needed
+
+######################################################
+# attach policies to cloudwatch-agent role
+# allows agent to create and write to log
+
+resource "aws_iam_role_policy_attachment" "attach-cloudwatch-agent-admin" {
+  role       = "${aws_iam_role.cloudwatch-agent.name}"
+  policy_arn = "arn:aws:iam::aws:policy/CloudWatchAgentAdminPolicy"
+}
+
+resource "aws_iam_role_policy_attachment" "attach-cloudwatch-agent-ssm" {
+  role       = "${aws_iam_role.cloudwatch-agent.name}"
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonEC2RoleforSSM"
+}
+
+resource "aws_iam_instance_profile" "cloudwatch-agent-profile" {
+  name = "CloudwatchAgentAdminProfile"
+  role = "${aws_iam_role.cloudwatch-agent.name}"
+}

--- a/308620678440/iam/s3-access-policy.tf
+++ b/308620678440/iam/s3-access-policy.tf
@@ -4,7 +4,7 @@
 resource "aws_iam_policy" "s3-policy-3" {
   name        = "s3-shared-test3"
   path        = "/"
-  description = "Policy for access to s3 shared-test-data-ju with no console read, list only on ju2 and jure-content"
+  description = "Policy for access to s3 shared-test-data-ju buckets"
 
   policy = <<EOF
 {
@@ -19,7 +19,7 @@ resource "aws_iam_policy" "s3-policy-3" {
             ],
             "Resource": [
                 "arn:aws:s3:::shared-test-data-ju",
-                "arn:aws:s3:::shared-test-data-ju2",
+                "arn:aws:s3:::shared-test-data-ju2"
             ]
         },
         {
@@ -29,12 +29,12 @@ resource "aws_iam_policy" "s3-policy-3" {
                 "s3:GetObject",
                 "s3:PutObject",
 	        "s3:GetObjectAcl",
-                "s3:PutObjectAcl"
+                "s3:PutObjectAcl",
 		"s3:DeleteObject"
             ],
             "Resource": [
                 "arn:aws:s3:::shared-test-data-ju/*",
-                "arn:aws:s3:::shared-test-data-ju2/*"
+                "arn:aws:s3:::shared-test-data-ju2/*",
                 "arn:aws:s3:::shared-test-data-ju3/*"
             ]
         }

--- a/308620678440/iam/s3-access-policy.tf
+++ b/308620678440/iam/s3-access-policy.tf
@@ -1,10 +1,12 @@
 /* s3 policies file
+THIS IS A TEST drive - it can be deleted
+use aws_iam_role_policy  - this creates an inline policy
 */
 
-resource "aws_iam_policy" "s3-policy-3" {
-  name        = "s3-shared-test3"
-  path        = "/"
-  description = "Policy for access to s3 shared-test-data-ju buckets"
+#### create policy
+resource "aws_iam_role_policy" "s3-policy-shared" {
+  name        = "s3-shared"
+  role        = "s3-shared-test2"
 
   policy = <<EOF
 {
@@ -28,9 +30,9 @@ resource "aws_iam_policy" "s3-policy-3" {
             "Action": [
                 "s3:GetObject",
                 "s3:PutObject",
-	        "s3:GetObjectAcl",
+	              "s3:GetObjectAcl",
                 "s3:PutObjectAcl",
-		"s3:DeleteObject"
+		            "s3:DeleteObject"
             ],
             "Resource": [
                 "arn:aws:s3:::shared-test-data-ju/*",

--- a/308620678440/iam/terraform-build-role.tf
+++ b/308620678440/iam/terraform-build-role.tf
@@ -1,0 +1,229 @@
+/* role and policy for use with terraform-build */
+### creates IAM role for terraform-build2 and establishes the Trust Relationship
+## here I am using this as an assumed role with local creds from a user role
+
+resource "aws_iam_role" "terraform-build2" {
+  name = "terraform-build2"
+  max_session_duration    = "14400"
+  assume_role_policy      = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "0",
+      "Effect": "Allow",
+      "Principal": {
+        "AWS": "arn:aws:iam::308620678440:user/jure2"
+      },
+      "Action": "sts:AssumeRole",
+      "Condition": {}
+    }
+  ]
+}
+EOF
+
+  tags = {
+    Environment     = "sbx"
+    CreatedBy       = "terraform"
+    TestValue       = "none"
+  }
+}
+
+######################################################
+/* create managed policy for terraform build access rights
+   the vpc Sid section should not be needed since ec2:* is also covered - but I include it here
+   for reference - copied from AmazonVPCFullAccess service role
+   REMINDER: the heredoc section MUST have the initial {} at the beginning of the line!
+*/
+
+resource "aws_iam_policy" "terraform-build-policy" {
+  name        = "terraform-build2"
+  path        = "/"
+  description = "Policy for use with Terraform / Terragrunt"
+
+  policy = <<EOF
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Sid": "0",
+            "Effect": "Allow",
+            "Action": [
+                "iam:*",
+                "ec2:*",
+                "elasticloadbalancing:*",
+                "autoscaling:*",
+                "s3:*",
+                "cloudwatch:*",
+                "logs:*",
+                "events:*",
+                "cloudtrail:*",
+                "sns:*",
+                "route53:*",
+                "apigateway:*",
+                "lambda:*",
+                "kms:*",
+                "dynamodb:*",
+                "rds:*"
+            ],
+            "Resource": "*"
+        },
+        {
+            "Sid": "1",
+            "Effect": "Allow",
+            "Action": [
+                "ec2:AcceptVpcPeeringConnection",
+                "ec2:AcceptVpcEndpointConnections",
+                "ec2:AllocateAddress",
+                "ec2:AssignIpv6Addresses",
+                "ec2:AssignPrivateIpAddresses",
+                "ec2:AssociateAddress",
+                "ec2:AssociateDhcpOptions",
+                "ec2:AssociateRouteTable",
+                "ec2:AssociateSubnetCidrBlock",
+                            "ec2:AssociateVpcCidrBlock",
+                            "ec2:AttachClassicLinkVpc",
+                            "ec2:AttachInternetGateway",
+                            "ec2:AttachNetworkInterface",
+                            "ec2:AttachVpnGateway",
+                            "ec2:AuthorizeSecurityGroupEgress",
+                            "ec2:AuthorizeSecurityGroupIngress",
+                            "ec2:CreateCustomerGateway",
+                            "ec2:CreateDefaultSubnet",
+                            "ec2:CreateDefaultVpc",
+                            "ec2:CreateDhcpOptions",
+                            "ec2:CreateEgressOnlyInternetGateway",
+                            "ec2:CreateFlowLogs",
+                            "ec2:CreateInternetGateway",
+                            "ec2:CreateNatGateway",
+                            "ec2:CreateNetworkAcl",
+                            "ec2:CreateNetworkAcl",
+                            "ec2:CreateNetworkAclEntry",
+                            "ec2:CreateNetworkInterface",
+                            "ec2:CreateNetworkInterfacePermission",
+                            "ec2:CreateRoute",
+                            "ec2:CreateRouteTable",
+                            "ec2:CreateSecurityGroup",
+                            "ec2:CreateSubnet",
+                            "ec2:CreateTags",
+                            "ec2:CreateVpc",
+                            "ec2:CreateVpcEndpoint",
+                            "ec2:CreateVpcEndpointConnectionNotification",
+                            "ec2:CreateVpcEndpointServiceConfiguration",
+                            "ec2:CreateVpcPeeringConnection",
+                            "ec2:CreateVpnConnection",
+                            "ec2:CreateVpnConnectionRoute",
+                            "ec2:CreateVpnGateway",
+                            "ec2:DeleteCustomerGateway",
+                            "ec2:DeleteDhcpOptions",
+                            "ec2:DeleteEgressOnlyInternetGateway",
+                            "ec2:DeleteFlowLogs",
+                            "ec2:DeleteInternetGateway",
+                            "ec2:DeleteNatGateway",
+                            "ec2:DeleteNetworkAcl",
+                            "ec2:DeleteNetworkAclEntry",
+                            "ec2:DeleteNetworkInterface",
+                            "ec2:DeleteNetworkInterfacePermission",
+                            "ec2:DeleteRoute",
+                            "ec2:DeleteRouteTable",
+                            "ec2:DeleteSecurityGroup",
+                            "ec2:DeleteSubnet",
+                            "ec2:DeleteTags",
+                            "ec2:DeleteVpc",
+                            "ec2:DeleteVpcEndpoints",
+                            "ec2:DeleteVpcEndpointConnectionNotifications",
+                            "ec2:DeleteVpcEndpointServiceConfigurations",
+                            "ec2:DeleteVpcPeeringConnection",
+                            "ec2:DeleteVpnConnection",
+                            "ec2:DeleteVpnConnectionRoute",
+                            "ec2:DeleteVpnGateway",
+                            "ec2:DescribeAccountAttributes",
+                            "ec2:DescribeAddresses",
+                            "ec2:DescribeAvailabilityZones",
+                            "ec2:DescribeClassicLinkInstances",
+                            "ec2:DescribeCustomerGateways",
+                            "ec2:DescribeDhcpOptions",
+                            "ec2:DescribeEgressOnlyInternetGateways",
+                            "ec2:DescribeFlowLogs",
+                            "ec2:DescribeInstances",
+                            "ec2:DescribeInternetGateways",
+                            "ec2:DescribeKeyPairs",
+                            "ec2:DescribeMovingAddresses",
+                            "ec2:DescribeNatGateways",
+                            "ec2:DescribeNetworkAcls",
+                            "ec2:DescribeNetworkInterfaceAttribute",
+                            "ec2:DescribeNetworkInterfacePermissions",
+                            "ec2:DescribeNetworkInterfaces",
+                            "ec2:DescribePrefixLists",
+                            "ec2:DescribeRouteTables",
+                            "ec2:DescribeSecurityGroupReferences",
+                            "ec2:DescribeSecurityGroups",
+                            "ec2:DescribeStaleSecurityGroups",
+                            "ec2:DescribeSubnets",
+                            "ec2:DescribeTags",
+                            "ec2:DescribeVpcAttribute",
+                            "ec2:DescribeVpcClassicLink",
+                            "ec2:DescribeVpcClassicLinkDnsSupport",
+                            "ec2:DescribeVpcEndpointConnectionNotifications",
+                            "ec2:DescribeVpcEndpointConnections",
+                            "ec2:DescribeVpcEndpoints",
+                            "ec2:DescribeVpcEndpointServiceConfigurations",
+                            "ec2:DescribeVpcEndpointServicePermissions",
+                            "ec2:DescribeVpcEndpointServices",
+                            "ec2:DescribeVpcPeeringConnections",
+                            "ec2:DescribeVpcs",
+                            "ec2:DescribeVpnConnections",
+                            "ec2:DescribeVpnGateways",
+                            "ec2:DetachClassicLinkVpc",
+                            "ec2:DetachInternetGateway",
+                            "ec2:DetachNetworkInterface",
+                            "ec2:DetachVpnGateway",
+                            "ec2:DisableVgwRoutePropagation",
+                            "ec2:DisableVpcClassicLink",
+                            "ec2:DisableVpcClassicLinkDnsSupport",
+                            "ec2:DisassociateAddress",
+                            "ec2:DisassociateRouteTable",
+                            "ec2:DisassociateSubnetCidrBlock",
+                            "ec2:DisassociateVpcCidrBlock",
+                            "ec2:EnableVgwRoutePropagation",
+                            "ec2:EnableVpcClassicLink",
+                            "ec2:EnableVpcClassicLinkDnsSupport",
+                            "ec2:ModifyNetworkInterfaceAttribute",
+                            "ec2:ModifySubnetAttribute",
+                            "ec2:ModifyVpcAttribute",
+                            "ec2:ModifyVpcEndpoint",
+                            "ec2:ModifyVpcEndpointConnectionNotification",
+                            "ec2:ModifyVpcEndpointServiceConfiguration",
+                            "ec2:ModifyVpcEndpointServicePermissions",
+                            "ec2:ModifyVpcPeeringConnectionOptions",
+                            "ec2:ModifyVpcTenancy",
+                            "ec2:MoveAddressToVpc",
+                            "ec2:RejectVpcEndpointConnections",
+                            "ec2:RejectVpcPeeringConnection",
+                            "ec2:ReleaseAddress",
+                            "ec2:ReplaceNetworkAclAssociation",
+                            "ec2:ReplaceNetworkAclEntry",
+                            "ec2:ReplaceRoute",
+                            "ec2:ReplaceRouteTableAssociation",
+                            "ec2:ResetNetworkInterfaceAttribute",
+                            "ec2:RestoreAddressToClassic",
+                            "ec2:RevokeSecurityGroupEgress",
+                "ec2:RevokeSecurityGroupIngress",
+                "ec2:UnassignIpv6Addresses",
+                "ec2:UnassignPrivateIpAddresses",
+                "ec2:UpdateSecurityGroupRuleDescriptionsEgress",
+                "ec2:UpdateSecurityGroupRuleDescriptionsIngress"
+                ],
+                "Resource": "*"
+        }
+    ]
+}
+EOF
+}
+
+######################################################
+# attach policy to terraform-build2 role
+resource "aws_iam_role_policy_attachment" "attach-terraform-build2" {
+  role       = "${aws_iam_role.terraform-build2.name}"
+  policy_arn = "${aws_iam_policy.terraform-build-policy.arn}"
+}

--- a/308620678440/iam/vars.tf
+++ b/308620678440/iam/vars.tf
@@ -1,0 +1,3 @@
+variable "aws-region" {
+  default   = "us-west-2"
+}

--- a/308620678440/vpc/main.tf
+++ b/308620678440/vpc/main.tf
@@ -1,0 +1,3 @@
+terraform {
+  backend "s3" {}
+}

--- a/308620678440/vpc/outputs.tf
+++ b/308620678440/vpc/outputs.tf
@@ -1,0 +1,38 @@
+####################
+# vpc outputs
+output "vpc-private1-id" {
+  value = "${aws_vpc.vpc-private-1.id}"
+}
+
+output "vpc-private1-default-acl" {
+  value = "${aws_vpc.vpc-private-1.default_network_acl_id}"
+}
+
+output "vpc-private1-default-sg" {
+  value = "${aws_vpc.vpc-private-1.default_security_group_id}"
+}
+
+output "vpc-private1-default-routetable" {
+  value = "${aws_vpc.vpc-private-1.default_route_table_id}"
+}
+
+output "vpc-private1-dhcp" {
+  value = "${aws_vpc.vpc-private-1.dhcp_options_id}"
+}
+
+#######################
+# vpc subnet outputs
+output "vpc-subnet-1a" {
+  value = "${aws_subnet.vpc-private-1a.id}"
+}
+
+output "vpc-subnet-1b" {
+  value = "${aws_subnet.vpc-private-1b.id}"
+}
+
+#######################
+# vpc peering
+
+output "vpc-peering-1a" {
+  value = "${aws_vpc_peering_connection.vpc-peer-default-to-private-1a.id}"
+}

--- a/308620678440/vpc/provider.tf
+++ b/308620678440/vpc/provider.tf
@@ -1,0 +1,3 @@
+provider "aws" {
+  region       = "${var.aws-region}"
+}

--- a/308620678440/vpc/vars.tf
+++ b/308620678440/vpc/vars.tf
@@ -1,0 +1,3 @@
+variable "aws-region" {
+  default   = "us-west-2"
+}

--- a/308620678440/vpc/vpc.tf
+++ b/308620678440/vpc/vpc.tf
@@ -1,0 +1,66 @@
+resource "aws_vpc" "vpc-private-1" {
+  cidr_block                       = "192.168.0.0/24" #254 address range
+  assign_generated_ipv6_cidr_block = true  # needed for egress only gate
+
+  tags = {
+    Environment		= "sbx"
+    CreatedBy		  = "terraform"
+  }
+}
+
+resource "aws_subnet" "vpc-private-1a" {
+  vpc_id		        = "${aws_vpc.vpc-private-1.id}"
+  cidr_block		    = "192.168.0.0/26"
+  availability_zone = "us-west-2a"
+
+  tags = {
+    Environment     = "sbx"
+    CreatedBy       = "terraform"
+  }
+}
+
+resource "aws_subnet" "vpc-private-1b" {
+  vpc_id		        = "${aws_vpc.vpc-private-1.id}"
+  cidr_block		    = "192.168.0.64/26"
+  availability_zone = "us-west-2a"
+
+  tags = {
+    Environment     = "sbx"
+    CreatedBy       = "terraform"
+  }
+}
+
+resource "aws_vpc_peering_connection" "vpc-peer-default-to-private-1a" {
+  peer_vpc_id   = "${aws_vpc.vpc-private-1.id}" # accepter vpc
+  vpc_id        = "vpc-f6784393" #default vpc w internet gate requester vcp
+  auto_accept   = true
+
+  tags = {
+    Environment         = "sbx"
+    CreatedBy           = "terraform"
+  }
+}
+
+resource "aws_route" "peering-default-route" {
+  route_table_id            = "rtb-73c4ce16"
+  destination_cidr_block    = "192.168.0.0/26"
+  vpc_peering_connection_id = "${aws_vpc_peering_connection.vpc-peer-default-to-private-1a.id}"
+}
+
+resource "aws_route" "peering-private-1a-route" {
+  route_table_id            = "${aws_vpc.vpc-private-1.default_route_table_id}"
+  destination_cidr_block    = "172.31.16.0/20"
+  vpc_peering_connection_id = "${aws_vpc_peering_connection.vpc-peer-default-to-private-1a.id}"
+}
+
+resource "aws_egress_only_internet_gateway" "vpc-private1-egress" {
+    vpc_id = "${aws_vpc.vpc-private-1.id}"
+}
+
+### route for private egress
+resource "aws_route" "private1-egress-route" {
+  route_table_id            = "${aws_vpc.vpc-private-1.default_route_table_id}"
+  destination_ipv6_cidr_block = "::/0"
+  egress_only_gateway_id    = "${aws_egress_only_internet_gateway.vpc-private1-egress.id}"
+  depends_on                = ["aws_egress_only_internet_gateway.vpc-private1-egress"]
+}


### PR DESCRIPTION
adds Terraform resources for:

- vpc: private with 2 subnets, peered to default vpc, route table routes, egress_only
- cloudwatch: RDS low cpu alarm, event rule 
- iam: adds  terraform-build2 role, policy and policy_attachment

Note: CLoudwatch event rule for ec2-cron still needs an event_target